### PR TITLE
Ensure a valid CA cert is written to relations

### DIFF
--- a/lib/charms/icey_vault_k8s/v0/insecure_certificates.py
+++ b/lib/charms/icey_vault_k8s/v0/insecure_certificates.py
@@ -124,9 +124,12 @@ class InsecureCertificatesProvides(Object):
                 for common_name, certs in certificates.items():
                     logging.info(f"Setting {common_name} certificate_data for {self.model.unit}")
                     event.relation.data[self.model.unit][common_name] = json.dumps(certs)
-                logging.info(f"Setting CA to {ca} for {self.model.unit}")
-                event.relation.data[self.model.unit]['ca'] = str(ca)
-                event.relation.data[self.model.unit]['chain'] = str(ca)
+
+                # NOTE: ensure a good CA cert is written to the relation
+                if ca is not None:
+                    logging.info(f"Setting CA to {ca} for {self.model.unit}")
+                    event.relation.data[self.model.unit]['ca'] = str(ca)
+                    event.relation.data[self.model.unit]['chain'] = str(ca)
             else:
                 logger.info("CA isn't ready")
                 event.defer()


### PR DESCRIPTION
Early during the unit lifecycle before consuming applications present requests its quite possible that the string intepretation of the Python value None can get written to the relation for the ca and chain key.

Guard against this - consuming units will inteprete this as a string rather than being unset which will then cause hook errors when the charm parses the "None" string as a certificate.